### PR TITLE
Clarify twine call

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,11 @@ script provided:
 
 This will create a ``wheelhouse`` directory containing all the wheels that have been built. At this point, you can then choose to upload
 these to PyPI if you wish, using
-[twine](https://pypi.org/project/twine/).
+[twine](https://pypi.org/project/twine/).  E.g.:
+
+    twine upload wheelhouse/<pkgname>*.whl
+
+
 
 ### Further information
 


### PR DESCRIPTION
Minor suggestion for the README.

Note that I've not used `twine` on wheels like this before, so it was my educated guess about exactly how it was meant to be used.  @astrofrog can confirm if this is right, though.